### PR TITLE
fix bin checker

### DIFF
--- a/09-fuzz/bin-gritzko-check.c
+++ b/09-fuzz/bin-gritzko-check.c
@@ -64,6 +64,9 @@ int main(int argn, char **args) {
       if (student.mark < 0 || student.mark > 10)
         fail("mark");
     }
+    if (rd != 0) {
+        fail("student");
+    }
     close(fd);
   }
   fprintf(stderr, "OK\n");


### PR DESCRIPTION
Сейчас любые инпуты, размер которых меньше `sizeof(struct Student)`, получают ОК (так же ОК получают валидные инпуты, на конце которых есть мусор размера меньше `sizeof(struct Student)`). Добавил обработку этих случаев.

(Возможно, еще хорошо было бы не завязываться на то, что read() всегда сможет прочитать все доступные байты, но это, вероятно, не выстрелит с обычными файлами)