### PR TITLE
[01-git][Python][bugfix] Belyakov Sergey

### DIFF
--- a/01-git/ls-belyakov.py
+++ b/01-git/ls-belyakov.py
@@ -15,12 +15,14 @@ def ls(root, prefix):
             hash = next(iter(hash), None)
 
             if name.endswith(':'):
+                if name[:-1] == ".commit":
+                    continue
                 print(prefix + name[:-1])
             elif name.endswith('/'):
                 if name[:-1] == ".parent":
                     continue
                 print(prefix + name)
-                ls(hash, prefix + "/" + name)
+                ls(hash, prefix + name)
             else:
                 raise Exception("FS format compromised")
 


### PR DESCRIPTION
Я пропустил пару багов в прошлом pr, подумал, что как-то некрасиво будет так оставлять в финальном репозитории.
Вроде починил оба бага, теперь выводит такое:
```
(base) serg-belyakov@serg-belyakov-x:~/Documents/HSE/decsys/practice/01-git/example$ cat 60b4164cecf8868ae6954342c42b2af562c4320e29bca52c10f5b1e0257d2b78
.commit:	8aa483d001511946d2fa07ede3a728e663b8e2d091fec478eec2220dd1a78574
README:	dd504747dc5604cd0a7ea3386a308648847478595f959dd7a8394bdda803c428
hello.txt:	0ba904eae8773b70c75333db4de2f3ac45a8ad4ddba1b242f0b3cfc199391dd8
subdir/	3d62f817d03c264005ce8b1fc61f777945b4a95140b8163525680f6b6e4cad25
(base) serg-belyakov@serg-belyakov-x:~/Documents/HSE/decsys/practice/01-git/example$ ./ls . 60b4164cecf8868ae6954342c42b2af562c4320e29bca52c10f5b1e0257d2b78
README
hello.txt
subdir/
subdir/subsubdir/
subdir/subsubdir/subsubsubdir/
```